### PR TITLE
Directory and Error extension methods

### DIFF
--- a/DirectoryExt.cs
+++ b/DirectoryExt.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Godot;
+
+using JetBrains.Annotations;
+
+namespace GodotExt
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Directory"/>.
+    /// </summary>
+    [PublicAPI]
+    public static class DirectoryExt
+    {
+        /// <summary>
+        /// Returns the complete file paths of all files inside <paramref name="directory"/>.
+        /// </summary>
+        /// <param name="directory">The <see cref="Directory"/> to search in.</param>
+        /// <param name="recursive">Whether the search should be conducted recursively (return paths of files inside <paramref name="directory"/>'s subdirectories and so on) or not.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of the paths of all files inside <paramref name="directory"/>.</returns>
+        [MustUseReturnValue]
+        public static IEnumerable<string> GetFiles(this Directory directory, bool recursive = false)
+        {
+            return recursive
+                ? directory.GetDirectories(true)
+                    .SelectMany(path =>
+                    {
+                        Directory recursiveDirectory = new Directory();
+                        recursiveDirectory.Open(path);
+                        return recursiveDirectory.GetElementsNonRecursive(true);
+                    })
+                    .Concat(directory.GetElementsNonRecursive(true))
+                : directory.GetElementsNonRecursive(true);
+        }
+        
+        /// <summary>
+        /// Returns the complete file paths of all files inside <paramref name="directory"/> whose extensions match any of <paramref name="fileExtensions"/>.
+        /// </summary>
+        /// <param name="directory">The <see cref="Directory"/> to search in.</param>
+        /// <param name="recursive">Whether the search should be conducted recursively (return paths of files inside <paramref name="directory"/>'s subdirectories and so on) or not.</param>
+        /// <param name="fileExtensions">The file extensions to search for. If none are provided, all file paths are returned.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of the paths of all files inside <paramref name="directory"/> whose extensions match any of <paramref name="fileExtensions"/>.</returns>
+        [MustUseReturnValue]
+        public static IEnumerable<string> GetFiles(this Directory directory, bool recursive = false, params string[] fileExtensions)
+        {
+            return fileExtensions.Any()
+                ? directory.GetFiles(recursive)
+                    .Where(file => fileExtensions.Any(file.EndsWith))
+                : directory.GetFiles(recursive);
+        }
+
+        /// <summary>
+        /// Returns the complete directory paths of all directories inside <paramref name="directory"/>.
+        /// </summary>
+        /// <param name="directory">The <see cref="Directory"/> to search in.</param>
+        /// <param name="recursive">Whether the search should be conducted recursively (return paths of directories inside <paramref name="directory"/>'s subdirectories and so on) or not.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of the paths of all files inside <paramref name="directory"/>.</returns>
+        [MustUseReturnValue]
+        public static IEnumerable<string> GetDirectories(this Directory directory, bool recursive = false)
+        {
+            return recursive
+                ? directory.GetElementsNonRecursive(false)
+                    .SelectMany(path =>
+                    {
+                        Directory recursiveDirectory = new Directory();
+                        recursiveDirectory.Open(path);
+                        return recursiveDirectory.GetDirectories(true).Prepend(path);
+                    })
+                : directory.GetElementsNonRecursive(false);
+        }
+        
+        [MustUseReturnValue]
+        private static IEnumerable<string> GetElementsNonRecursive(this Directory directory, bool trueIfFiles)
+        {
+            directory.ListDirBegin(true);
+            while (true)
+            {
+                string next = directory.GetNext();
+                if (next is "")
+                {
+                    yield break;
+                }
+                if (directory.CurrentIsDir() == trueIfFiles)
+                {
+                    continue;
+                }
+                string current = directory.GetCurrentDir();
+                yield return current.EndsWith("/") ? $"{current}{next}" : $"{current}/{next}";
+            }
+        }
+    }
+}

--- a/ErrorExt.cs
+++ b/ErrorExt.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.CompilerServices;
+
+using Godot;
+
+using JetBrains.Annotations;
+
+namespace GodotExt
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Error"/>.
+    /// </summary>
+    [PublicAPI]
+    public static class ErrorExt
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if there is no error.
+        /// </summary>
+        /// <param name="error">The <see cref="Error"/> to check.</param>
+        /// <returns><see langword="true"/> if there is no error, else <see langword="false"/>.</returns>
+        [Pure]
+        public static bool Success(this Error error)
+        {
+            return error is Error.Ok;
+        }
+        
+        /// <summary>
+        /// Throws an <see cref="Exception"/> if <paramref name="error"/> is not <see cref="Error.Ok"/>.
+        /// </summary>
+        /// <param name="error">The <see cref="Error"/> to check.</param>
+        /// <param name="message">An optional message to include if an <see cref="Exception"/> is thrown.</param>
+        /// <param name="filePath">The file path of the code that failed.</param>
+        /// <param name="line">The line number of the code that failed.</param>
+        public static void ThrowIfFailed(this Error error, [CanBeNull] string message = null, [CallerFilePath] string filePath = "<unknown>", [CallerLineNumber] int line = -1)
+        {
+            if (error is Error.Ok)
+            {
+                return;
+            }
+            string fullMessage = message is null ? $"Error ({error}) at {filePath}:{line}" : $"Error ({error}) at {filePath}:{line} - {message}";
+            throw new Exception(fullMessage);
+        }
+    }
+}


### PR DESCRIPTION
I have added extension methods for `Directory` and `Error`.

`DirectoryExt.GetFiles()` and `DirectoryExt.GetDirectories()` do what their `System.IO.Directory` counterparts do, and thus help make Godot's filesystem API less of a pain to work with.

`ErrorExt.Success()` makes it possible to check whether an error occurred or not, without having to use `!=` or `is not` all the time.  
`ErrorExt.ThrowIfFailed()` makes it easy to throw an exception (and therefore terminate the application) if an `Error` is returned by Godot, without having to use an `if` statement and compose an error message manually.